### PR TITLE
Allow any media type to be imported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ wp acorn vendor:publish --provider="istogram\WpApiContentMigration\Providers\Con
 
 ### Allow non-standard media uploads
 
-If you want to allow non-standard media uploads you will need to set the config option:
+If you want to allow non-standard media uploads you will need to set the config option by default only WordPress standard media types are allowed. 
 
 ```php
 'allow_media' => [

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ wp acorn vendor:publish --provider="istogram\WpApiContentMigration\Providers\Con
 
 ## Configuration
 
-### Allow SVG media uploads
+### Allow non-standard media uploads
 
-If you want to allow SVG media uploads you will need to set the config option:
+If you want to allow non-standard media uploads you will need to set the config option:
 
 ```php
-'allow_svg_media' => true
+'allow_media' => [
+  'svg' => 'image/svg+xml',
+],
 ```
 
 ## Usage

--- a/config/content-migration.php
+++ b/config/content-migration.php
@@ -23,10 +23,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Allow SVG media
+    | Allow media
     |--------------------------------------------------------------------------
     |
-    | Set to true to allow SVG media files to be imported.
+    | Set to allow diffrent non-standard WordPress files to be imported.
+    | allow_media => ['svg' => 'image/svg+xml']
     */
-    'allow_svg_media' => false,
+    'allow_media' => false,
 ];

--- a/src/ContentMigration.php
+++ b/src/ContentMigration.php
@@ -22,17 +22,20 @@ class ContentMigration
     {
         $this->app = $app;
 
-        $fileTypes = $this->app['config']->get('content-migration.allow_media');
-
-        if (!empty($fileTypes) && is_array($fileTypes) && $fileTypes !== false) {
-            add_filter('upload_mimes', function ($mimes) {
-                foreach ($fileTypes as $key => $fileType) {
-                    $mimes[$key] = $fileType;
+        if (!empty($this->app['config']->get('content-migration.mime_types'))) {
+            try {
+                add_filter('upload_mimes', function ($mimes) use ($mime_types) {
+                    foreach ($this->app['config']->get('content-migration.mime_types') as $key => $fileType) {
+                        $mimes[$key] = $fileType;
+                    }
                     return $mimes;
-                }
-            });
+                });
+            } catch (\Exception $e) {
+                $this->app->log->info('Error with mime type : ' . $e->getMessage());
+            }
         }
     }
+
 
     /**
      * Create WP category. This method also sets the parent category if it exists.

--- a/src/ContentMigration.php
+++ b/src/ContentMigration.php
@@ -22,10 +22,10 @@ class ContentMigration
     {
         $this->app = $app;
 
-        if (!empty($this->app['config']->get('content-migration.mime_types'))) {
+        if (!empty($this->app['config']->get('content-migration.allow_media'))) {
             try {
-                add_filter('upload_mimes', function ($mimes) use ($mime_types) {
-                    foreach ($this->app['config']->get('content-migration.mime_types') as $key => $fileType) {
+                add_filter('upload_mimes', function ($mimes) {
+                    foreach ($this->app['config']->get('content-migration.allow_media') as $key => $fileType) {
                         $mimes[$key] = $fileType;
                     }
                     return $mimes;


### PR DESCRIPTION
Expanding on the svg import and allow anyone to import any file type: - 

```'allow_media' => false,``` -  Standard WP media.

and 

```allow_media => ['svg' => 'image/svg+xml']``` - Standard WP media + svgs

Allow media should allow developers to import **any** media type into WordPress.

I've only tested this with the a media gallery containing SVG's for now.

P.s. Please go easy on me this is the first time I've tried to submit a proper pr, I'm not sure how you're running tests on this lib but like I said I tested this very quickly I'd give it a whirl testing it before merging.